### PR TITLE
Improve model selection UX: stable order in expanded view and auto-scroll

### DIFF
--- a/packages/stage-pages/src/pages/settings/modules/consciousness.vue
+++ b/packages/stage-pages/src/pages/settings/modules/consciousness.vue
@@ -177,7 +177,7 @@ function handleDeleteProvider(providerId: string) {
           <RadioCardManySelect
             v-model="activeModel"
             v-model:search-query="modelSearchQuery"
-            :items="providerModels.sort((a, b) => a.id === activeModel ? -1 : b.id === activeModel ? 1 : 0)"
+            :items="providerModels"
             :searchable="true"
             :allow-custom="true"
             :search-placeholder="t('settings.pages.modules.consciousness.sections.section.provider-model-selection.search_placeholder')"

--- a/packages/stage-ui/src/components/menu/radio-card-many-select.vue
+++ b/packages/stage-ui/src/components/menu/radio-card-many-select.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 
 import Alert from '../misc/alert.vue'
 import RadioCardDetail from './radio-card-detail.vue'
@@ -52,6 +52,19 @@ const searchQuery = defineModel<string>('searchQuery')
 
 const isListExpanded = ref(false)
 const customValue = ref('')
+const listContainer = ref<HTMLElement | null>(null)
+
+watch(isListExpanded, (expanded) => {
+  if (expanded) {
+    nextTick(() => {
+      if (listContainer.value && modelValue.value) {
+        const selectedElement = listContainer.value.querySelector(`[data-value="${CSS.escape(modelValue.value)}"]`)
+        if (selectedElement)
+          selectedElement.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      }
+    })
+  }
+})
 
 // Constants for scoring to make behavior explicit and tunable
 const SCORE_EXACT = 100
@@ -122,6 +135,17 @@ const filteredItems = computed(() => {
       .sort((a, b) => b.score - a.score)
       .map(({ item }) => item)
   }
+  else if (!isListExpanded.value) {
+    // If not searching and not expanded, sort by selection (selected first)
+    // This maintains the "collapsed view" behavior where the selected item is first
+    result.sort((a, b) => {
+      if (a.id === modelValue.value)
+        return -1
+      if (b.id === modelValue.value)
+        return 1
+      return 0
+    })
+  }
 
   // Add "Use custom: ..." option if searching and custom input is allowed
   if (props.allowCustom && searchQuery.value) {
@@ -186,6 +210,7 @@ function updateCustomValue(value: string) {
       <div class="relative">
         <!-- Responsive grid container -->
         <div
+          ref="listContainer"
           :class="[
             isListExpanded
               ? 'grid grid-cols-1 md:grid-cols-2 gap-4'
@@ -209,6 +234,7 @@ function updateCustomValue(value: string) {
             :key="item.id"
             v-model="modelValue"
             :value="item.id"
+            :data-value="item.id"
             :title="item.name"
             :description="item.description"
             :deprecated="item.deprecated"

--- a/packages/stage-ui/src/components/menu/radio-card-many-select.vue
+++ b/packages/stage-ui/src/components/menu/radio-card-many-select.vue
@@ -53,6 +53,40 @@ const searchQuery = defineModel<string>('searchQuery')
 const isListExpanded = ref(false)
 const customValue = ref('')
 
+// Constants for scoring to make behavior explicit and tunable
+const SCORE_EXACT = 100
+const SCORE_STARTS_WITH = 80
+const SCORE_INCLUDES = 60
+const SCORE_SUBSEQUENCE = 40
+const DESC_WEIGHT = 0.5
+
+function getMatchScore(query: string, text: string): number {
+  if (!text)
+    return 0
+  const q = query.toLowerCase()
+  const t = text.toLowerCase()
+
+  if (t === q)
+    return SCORE_EXACT
+  if (t.startsWith(q))
+    return SCORE_STARTS_WITH
+  if (t.includes(q))
+    return SCORE_INCLUDES
+
+  // Subsequence check
+  let i = 0
+  let j = 0
+  while (i < q.length && j < t.length) {
+    if (q[i] === t[j])
+      i++
+    j++
+  }
+  if (i === q.length)
+    return SCORE_SUBSEQUENCE
+
+  return 0
+}
+
 const filteredItems = computed(() => {
   let result = [...props.items]
 
@@ -66,12 +100,27 @@ const filteredItems = computed(() => {
     })
   }
 
-  if (searchQuery.value) {
-    const query = searchQuery.value.toLowerCase()
-    result = result.filter(item =>
-      item.name.toLowerCase().includes(query)
-      || (item.description && item.description.toLowerCase().includes(query)),
-    )
+  const trimmedQuery = searchQuery.value?.trim()
+
+  if (trimmedQuery && trimmedQuery.length > 0) {
+    // Map items to items with scores
+    const scoredItems = result.map((item) => {
+      const nameScore = getMatchScore(trimmedQuery, item.name)
+      const descScore = item.description ? getMatchScore(trimmedQuery, item.description) * DESC_WEIGHT : 0
+      // Normalize id to string to avoid runtime errors if IDs are numbers/mixed
+      const idScore = getMatchScore(trimmedQuery, String(item.id))
+
+      return {
+        item,
+        score: Math.max(nameScore, descScore, idScore),
+      }
+    })
+
+    // Filter and sort
+    result = scoredItems
+      .filter(({ score }) => score > 0)
+      .sort((a, b) => b.score - a.score)
+      .map(({ item }) => item)
   }
 
   // Add "Use custom: ..." option if searching and custom input is allowed
@@ -80,7 +129,7 @@ const filteredItems = computed(() => {
     // Check against checks if the exact ID exists to avoid duplicates
     const exactMatch = result.some(i => i.id.toLowerCase() === query.toLowerCase())
     if (!exactMatch) {
-      result.push({
+      result.unshift({
         id: query,
         name: query,
         description: props.customOptionDescription,


### PR DESCRIPTION
Improved the UX of the model selection list in the Consciousness settings module.
Previously, the list was re-sorted to place the selected item at the top, causing the list to jump around when selecting different items.
The new behavior keeps the selected item at the top only in the collapsed view. In the expanded view, the original order is preserved, and the list automatically scrolls to the currently selected item.

Changes:
- Modified `packages/stage-pages/src/pages/settings/modules/consciousness.vue` to remove inline sorting.
- Modified `packages/stage-ui/src/components/menu/radio-card-many-select.vue` to implement conditional sorting and auto-scrolling logic.


---
*PR created automatically by Jules for task [13019296202403250717](https://jules.google.com/task/13019296202403250717) started by @shinohara-rin*

## Summary by Sourcery

Improve the model selection UX by keeping the selected item first only in the collapsed view while preserving original order in the expanded list and auto-scrolling to the selected item.

Enhancements:
- Adjust model list sorting so the selected model is prioritized only in the collapsed view and no longer reorders the expanded list.
- Add automatic scrolling to center the currently selected model when expanding the model list.